### PR TITLE
Allow php.ini changes for all variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,29 @@ To set the UID for the www-data user (and by extension, the PHP-FPM process), yo
 
 # php.ini directives
 
-You can modify certain php.ini directives by setting environmental variables within the container. The following is a list of environmental variables and the php.ini directives that they correspond to:
+You can modify any php.ini directives by setting environmental variables within the container. It can be accomplish by prefixing the variable with the place to be replace ( FPM, CLI or ALL for both ).
+If the variable contains a dot `.` in it you can accomplish this by using a double underscore `__` on the variable name. The following are some examples of how to accomplish this:
 
-| environmental variable  | php.ini directives                                                                       |
-|-------------------------|---------------------------------------------------------------------------------------|
-| `PHP_POST_MAX_SIZE`       | [`post_max_size`](http://php.net/manual/en/ini.core.php#ini.post-max-size)              |
-| `PHP_UPLOAD_MAX_FILESIZE` | [`upload_max_filesize`](http://php.net/manual/en/ini.core.php#ini.upload-max-filesize)  |
+| environmental variable         | php.ini directives                                                                                        |
+|--------------------------------|-----------------------------------------------------------------------------------------------------------|
+| `PHP_FPM_POST_MAX_SIZE`        | [`post_max_size`](http://php.net/manual/en/ini.core.php#ini.post-max-size)                                |
+| `PHP_ALL_UPLOAD_MAX_FILESIZE`  | [`upload_max_filesize`](http://php.net/manual/en/ini.core.php#ini.upload-max-filesize)                    |
+| `PHP_CLI_MAX_FILE_UPLOADS`     | [`max_file_uploads`](https://php.net/manual/en/ini.core.php#ini.max-file-uploads)                         |
+| `PHP_FPM_PM__MAX_CHILDREN`     | [`pm.max_children`](https://www.php.net/manual/en/install.fpm.configuration.php#pm.max-children)          |
+| `PHP_ALL_SESSION__SAVE_PATH`   | [`session.save_path`](https://www.php.net/manual/en/session.configuration.php#ini.session.save-path)      |
+| `PHP_ALL_SESSION__SAVE_HANDLER`| [`session.save_handler`](https://www.php.net/manual/en/session.configuration.php#ini.session.save-handler)|
 
-e.g. the following will start a PHP container with the `post_max_size` to 30 Megabytes:
+e.g. the following will start a PHP container with the `post_max_size` to 30 Megabytes for both CLI and FPM:
 
-`docker run -e PHP_POST_MAX_SIZE=30M chekote/php:7`
+`docker run -e PHP_ALL_UPLOAD_MAX_FILESIZE=30M chekote/php:7`
+
+and the following will start a PHP container with the `pm.max_children` setting to 50 for FPM processes:
+
+`docker run -e PHP_FPM_PM__MAX_CHILDREN=50 chekote/php:7`
+
+and the following will start a PHP container with the `session.save_handler` on both FPM and CLI using redis:
+
+`docker run -e PHP_ALL_SESSION__SAVE_HANDLER=redis chekote/php:7`
 
 # Distribution
 

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ To set the UID for the www-data user (and by extension, the PHP-FPM process), yo
 You can modify any php.ini directives by setting environmental variables within the container. It can be accomplish by prefixing the variable with the place to be replace ( FPM, CLI or ALL for both ).
 If the variable contains a dot `.` in it you can accomplish this by using a double underscore `__` on the variable name. The following are some examples of how to accomplish this:
 
-| environmental variable         | php.ini directives                                                                                        |
-|--------------------------------|-----------------------------------------------------------------------------------------------------------|
-| `PHP_FPM_POST_MAX_SIZE`        | [`post_max_size`](http://php.net/manual/en/ini.core.php#ini.post-max-size)                                |
-| `PHP_ALL_UPLOAD_MAX_FILESIZE`  | [`upload_max_filesize`](http://php.net/manual/en/ini.core.php#ini.upload-max-filesize)                    |
-| `PHP_CLI_MAX_FILE_UPLOADS`     | [`max_file_uploads`](https://php.net/manual/en/ini.core.php#ini.max-file-uploads)                         |
-| `PHP_FPM_PM__MAX_CHILDREN`     | [`pm.max_children`](https://www.php.net/manual/en/install.fpm.configuration.php#pm.max-children)          |
-| `PHP_ALL_SESSION__SAVE_PATH`   | [`session.save_path`](https://www.php.net/manual/en/session.configuration.php#ini.session.save-path)      |
-| `PHP_ALL_SESSION__SAVE_HANDLER`| [`session.save_handler`](https://www.php.net/manual/en/session.configuration.php#ini.session.save-handler)|
+| environmental variable         | php.ini directives                                                                                        | php.ini config file |
+|--------------------------------|-----------------------------------------------------------------------------------------------------------|---------------------|
+| `PHP_FPM_POST_MAX_SIZE`        | [`post_max_size`](http://php.net/manual/en/ini.core.php#ini.post-max-size)                                | fpm                 |
+| `PHP_ALL_UPLOAD_MAX_FILESIZE`  | [`upload_max_filesize`](http://php.net/manual/en/ini.core.php#ini.upload-max-filesize)                    | fpm, cli            |
+| `PHP_CLI_MAX_FILE_UPLOADS`     | [`max_file_uploads`](https://php.net/manual/en/ini.core.php#ini.max-file-uploads)                         | cli                 |
+| `PHP_FPM_PM__MAX_CHILDREN`     | [`pm.max_children`](https://www.php.net/manual/en/install.fpm.configuration.php#pm.max-children)          | fpm                 |
+| `PHP_ALL_SESSION__SAVE_PATH`   | [`session.save_path`](https://www.php.net/manual/en/session.configuration.php#ini.session.save-path)      | fpm, cli            |
+| `PHP_ALL_SESSION__SAVE_HANDLER`| [`session.save_handler`](https://www.php.net/manual/en/session.configuration.php#ini.session.save-handler)| fpm, cli            |
 
 e.g. the following will start a PHP container with the `post_max_size` to 30 Megabytes for both CLI and FPM:
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env sh
 
 if [ "$PHP_FPM_USER_ID" != "" ]; then
-    usermod -u $PHP_FPM_USER_ID nobody
+    (>&2 echo "Warning: PHP_FPM_USER_ID is deprecated. Please use WWW_DATA_USER_ID instead.")
+    WWW_DATA_USER_ID=$PHP_FPM_USER_ID
+fi
+
+# Set the uid that www-data will run as if one was specified
+if [ "$WWW_DATA_USER_ID" != "" ]; then
+    usermod -u $WWW_DATA_USER_ID www-data
 fi
 
 replace_in_file() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ replace_in_file() {
 
 # Set php.ini options
 for TYPE in cli fpm; do
-    PHP_INI=/etc/php/${PHP_MAJOR_VERSION}/${TYPE}/php.ini
+    PHP_INI=/etc/php/${PHP_VERSION}/${TYPE}/php.ini
     VAR_TYPE=`echo "PHP_$TYPE" | tr '[:lower:]' '[:upper:]'`
 
     # Replace all variables ( prefixed by PHP_TYPE ) on the proper PHP type file

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,28 +1,41 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 if [ "$PHP_FPM_USER_ID" != "" ]; then
-    (>&2 echo "Warning: PHP_FPM_USER_ID is deprecated. Please use WWW_DATA_USER_ID instead.")
-    WWW_DATA_USER_ID=$PHP_FPM_USER_ID
+    usermod -u $PHP_FPM_USER_ID nobody
 fi
 
-# Set the uid that www-data will run as if one was specified
-if [ "$WWW_DATA_USER_ID" != "" ]; then
-    usermod -u $WWW_DATA_USER_ID www-data
-fi
+replace_in_file() {
+    PHP_FILE=${1}
+    VAR_MATCH=${2}
+    REPLACE_VARS=`printenv | awk -F'=' '{print $1}' | grep -E "^$2"`
 
-# Set php.ini options
-for TYPE in cli fpm; do
-    PHP_INI=/etc/php/${PHP_VERSION}/${TYPE}/php.ini
+    # If there are variables to be replace move forward
+    if [ ! -z "$REPLACE_VARS" ]; then
+      for VAR_NAME in $REPLACE_VARS; do
+        # get the directive name by removing the prefixes e.g. PHP_CLI and making them lowercase.
+        # if there are any double '_' replace with a dot.
+        DIRECTIVE=`echo "$VAR_NAME" | cut -c9- | tr '[:upper:]' '[:lower:]' | sed 's/__/./g'`
+        VALUE=`printenv "$VAR_NAME"`
 
-    # Update the PHP upload_max_filesize setting if one was specified
-    if [ "$PHP_UPLOAD_MAX_FILESIZE" != "" ]; then
-        sed -i "s!upload_max_filesize = 2M!upload_max_filesize = $PHP_UPLOAD_MAX_FILESIZE!g" "$PHP_INI"
+        # Replace the variable only if it starts with the name of the directive and remove optional ';'
+        sed -i "s!^\(;\)\{0,1\}$DIRECTIVE = [^\n]\+!$DIRECTIVE = $VALUE!g" "$PHP_FILE"
+      done
     fi
+}
 
-    # Update the post_max_size setting if one was specified
-    if [ "$PHP_POST_MAX_SIZE" != "" ]; then
-        sed -i "s!post_max_size = 8M!post_max_size = $PHP_POST_MAX_SIZE!g" "$PHP_INI"
-    fi
-done
+
+# Set the php.ini file locations.
+PHP_CLI_INI=/etc/php/$PHP_MAJOR_VERSION/cli/php.ini
+PHP_FPM_INI=/etc/php/$PHP_MAJOR_VERSION/fpm/php.ini
+
+# Replace all CLI variables ( prefixed by CLI )
+replace_in_file $PHP_CLI_INI "PHP_CLI"
+
+# Replace all FPM variables ( prefixed by FPM )
+replace_in_file $PHP_FPM_INI "PHP_FPM"
+
+# Replace variables on both files ( prefixed by ALL ).
+replace_in_file $PHP_CLI_INI "PHP_ALL"
+replace_in_file $PHP_FPM_INI "PHP_ALL"
 
 /usr/local/bin/entrypoint.sh "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 if [ "$PHP_FPM_USER_ID" != "" ]; then
     (>&2 echo "Warning: PHP_FPM_USER_ID is deprecated. Please use WWW_DATA_USER_ID instead.")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,19 +29,16 @@ replace_in_file() {
     fi
 }
 
+# Set php.ini options
+for TYPE in cli fpm; do
+    PHP_INI=/etc/php/${PHP_MAJOR_VERSION}/${TYPE}/php.ini
+    VAR_TYPE=`echo "PHP_$TYPE" | tr '[:lower:]' '[:upper:]'`
 
-# Set the php.ini file locations.
-PHP_CLI_INI=/etc/php/$PHP_MAJOR_VERSION/cli/php.ini
-PHP_FPM_INI=/etc/php/$PHP_MAJOR_VERSION/fpm/php.ini
+    # Replace all variables ( prefixed by PHP_TYPE ) on the proper PHP type file
+    replace_in_file $PHP_INI $VAR_TYPE
 
-# Replace all CLI variables ( prefixed by CLI )
-replace_in_file $PHP_CLI_INI "PHP_CLI"
-
-# Replace all FPM variables ( prefixed by FPM )
-replace_in_file $PHP_FPM_INI "PHP_FPM"
-
-# Replace variables on both files ( prefixed by ALL ).
-replace_in_file $PHP_CLI_INI "PHP_ALL"
-replace_in_file $PHP_FPM_INI "PHP_ALL"
+    # Replace all variables ( prefixed by PHP_ALL )
+    replace_in_file $PHP_INI "PHP_ALL"
+done
 
 /usr/local/bin/entrypoint.sh "$@"


### PR DESCRIPTION
### Issue:
While using this php image in order to change php ini settings it isn't possible other than the currently 2 supported. This causes issues as php has many configurations which would be handy to change on different environments or be able to change with a simple command over them being set by modifying the php.ini script directly.

### Solution:
This PR will solve this issue by allowing the use of prefixed environment variables `PHP` to ensure that these are for changing php.ini variables only and then adding the extra prefixes `CLI` `FPM` and `ALL` to allow these variables to be modified in CLI, FPM or both environments.
In order to accomplish changes on variables that might have dots `.` on them such as `session.save_path` the variable name should have a double underscore `__` that will be replaced for a dot when parsing the file.

- allow changes of any php.ini variables. by using prefixes on the env variables set to the container
- update readme file to reflect changes.