### PR TITLE
Fix PHP Directives with no space

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,8 +14,9 @@ replace_in_files() {
         VALUE=`printenv "$VAR_NAME"`
 
         # Replace the variable only if it starts with the name of the directive and remove optional ';'
+        # Some directives will not have spaces after the directive name. i.e opcache
         find $PHP_CONFIG_FILES -type f -exec \
-            sed -i "s/^\(;\)\{0,1\}$DIRECTIVE = [^\n]\+/$DIRECTIVE = $VALUE/g" {} \;
+            sed -i "s/^\(;\)\{0,1\}$DIRECTIVE\( \)\{0,1\}=.*\+/$DIRECTIVE=$VALUE/g" {} \;
       done
     fi
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ replace_in_files() {
         # Replace the variable only if it starts with the name of the directive and remove optional ';'
         # Some directives will not have spaces after the directive name. i.e opcache
         find $PHP_CONFIG_FILES -type f -exec \
-            sed -i "s/^;\?$DIRECTIVE \?=.*\+/$DIRECTIVE=$VALUE/g" {} \;
+            sed -i "s/^;\?$DIRECTIVE \?=[^\n]*/$DIRECTIVE=$VALUE/g" {} \;
       done
     fi
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ replace_in_files() {
         # Replace the variable only if it starts with the name of the directive and remove optional ';'
         # Some directives will not have spaces after the directive name. i.e opcache
         find $PHP_CONFIG_FILES -type f -exec \
-            sed -i "s/^\(;\)\{0,1\}$DIRECTIVE\( \)\{0,1\}=.*\+/$DIRECTIVE=$VALUE/g" {} \;
+            sed -i "s/^;\?$DIRECTIVE \?=.*\+/$DIRECTIVE=$VALUE/g" {} \;
       done
     fi
 }

--- a/php.docker
+++ b/php.docker
@@ -26,7 +26,7 @@ RUN apt-get update && \
     rm -rf /var/cache/apt/* && \
     #
     # Fix "Unable to create the PID file (/run/php/php5.6-fpm.pid).: No such file or directory (2)"
-    mkdir /run/php && \
+    mkdir -p /run/php && \
     #
     # Configure PHP-FPM
     sed -i "s!display_startup_errors = Off!display_startup_errors = On!g" /etc/php/${PHP_VERSION}/fpm/php.ini && \


### PR DESCRIPTION
Optional space after directive name.
Remove spaces after = as not always present.

Example:

opcache options do not have spaces after the directive name and some have no content after the `=` sign. this causes them not work with current logic. reason why The following changes were made.

Test:
```
$ docker build -f php.docker .   
Successfully built c002d4e38e2e
$ docker run -e PHP_ALL_OPCACHE__FILE_CACHE="\/var\/cache\/php\/opcache" c002d4e38e2e cat /etc/php/7.3/fpm/php.ini | grep "opcache\."
opcache.file_cache=/var/cache/php/opcache
```