### PR TITLE
Create a symbolic link for the specific PHP-FPM version to the generic binary name

### DIFF
--- a/php-alpine.docker
+++ b/php-alpine.docker
@@ -46,8 +46,12 @@ RUN set -euo pipefail; \
     sed -i "s!;catch_workers_output =[^\n]*!catch_workers_output = yes!g" $PHP_WWW_FPM_CONF; \
     sed -i "s!\[error_log\] =[^\n]*/\$pool.error.log![error_log] = /proc/self/fd/2!g" $PHP_WWW_FPM_CONF; \
     #
+    # Create a symbolic link for the specific PHP-FPM version to the generic binary name
+    ln -sf /usr/sbin/php-fpm$PHP_VERSION /usr/sbin/php-fpm; \
+    #
     # Make sure everything works
     php -v; \
+    php-fpm -v; \
     php-fpm$PHP_VERSION -v
 
 WORKDIR /workdir

--- a/php.docker
+++ b/php.docker
@@ -47,8 +47,12 @@ RUN set -eu; \
     sed -i "s!;catch_workers_output = yes!catch_workers_output = yes!g" /etc/php/$PHP_VERSION/fpm/pool.d/www.conf; \
     sed -i "s!listen = /run/php/php${PHP_VERSION}-fpm.sock!listen = 0.0.0.0:9000!g" /etc/php/$PHP_VERSION/fpm/pool.d/www.conf; \
     #
+    # Create a symbolic link for the specific PHP-FPM version to the generic binary name
+    ln -sf /usr/sbin/php-fpm$PHP_VERSION /usr/sbin/php-fpm; \
+    #
     # Make sure everything works
     php -v; \
+    php-fpm -v; \
     php-fpm$PHP_VERSION -v
 
 WORKDIR /workdir


### PR DESCRIPTION
This pull request introduces a minor update to the PHP Docker setup to improve compatibility and usability with PHP-FPM. 
The most notable change is the creation of a symbolic link for the PHP-FPM binary, ensuring that tools and scripts expecting the generic `php-fpm` command will work seamlessly with the specified PHP version.

Improvements to PHP-FPM binary usage:

* Added a symbolic link from the version-specific `php-fpm$PHP_VERSION` binary to the generic `php-fpm` name in `/usr/sbin`, allowing consistent invocation of PHP-FPM regardless of the version.
* Added a verification step to display the version of the generic `php-fpm` binary, confirming the symlink works as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensure PHP-FPM is available via a generic invocation by creating a runtime symlink and adding build-time validation; prints PHP-FPM and PHP versions during container build to confirm availability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->